### PR TITLE
fix: capture the last section when it isn't followed by another MD section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+<!--
+- Rebase your branch on the latest upstream master
+- If this PR contains user facing change, please follow the checklist
+- Provide a general summary of your changes in the Title above
+-->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Checklist
+
+If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.
+
+- [ ] Added Changelog entries below
+
+## Changelog Inclusions
+
+<!-- Text Entered in these section will appear as it is written, MD formatted -->
+- base feature note
+  - **BREAKING** note on base feature
+  - Basically whatever formatting we have here, just plain-text
+       #> command example
+- next feature
+  - note on next feature
+<!-- If there is NO text in a section, no entries will be collected for that section -->
+
+### Additions
+
+### Changes
+
+### Fixes
+
+### Deprecated
+
+### Removed
+
+### Breaking Changes
+

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Generate", func() {
 		err               error
 		markdown          string
 		markdownAdditions string
+		markdownNoClosure string
 	)
 
 	AfterSuite(func() {
@@ -127,6 +128,22 @@ var _ = Describe("Generate", func() {
 
 `
 
+		markdownNoClosure = `## v0.2.0
+
+### Changes
+
+#### [Pull Request #0](https://github.com/splicemachine/splicectl/pull/0)
+
+- Change 1
+- Change 2
+
+#### [Pull Request #1](https://github.com/splicemachine/splicectl/pull/1)
+
+- Change 3
+- Change 4
+
+`
+
 	})
 
 	Describe("New Changelog", func() {
@@ -165,6 +182,17 @@ var _ = Describe("Generate", func() {
 				Expect(err).To(Equal(nil))
 			}
 			Expect(string(fileData[:])).To(Equal(markdown))
+		})
+
+		It("create a new changelog, change section, no closure", func() {
+			auth := clprovider.AuthToken{
+				GithubToken: "abcdefghijklmnop",
+			}
+			out, err := mockGitRepo.GetChangeLogFromPR("", "v0.0.3", "v0.2.0", auth, "")
+			if err != nil {
+				Expect(err).To(Equal(nil))
+			}
+			Expect(out).To(Equal(markdownNoClosure))
 		})
 
 	})

--- a/common/parse.go
+++ b/common/parse.go
@@ -5,6 +5,44 @@ import (
 	"strings"
 )
 
+func collectSectionText(cl *Changelog, sectionName string, sectionText string, pr string) {
+
+	switch sectionName {
+	case "## Changelog Inclusions.### Additions":
+		cl.Additions = append(cl.Additions, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+	case "## Changelog Inclusions.### Changes":
+		cl.Changes = append(cl.Changes, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+	case "## Changelog Inclusions.### Fixes":
+		cl.Bugfixes = append(cl.Bugfixes, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+	case "## Changelog Inclusions.### Deprecated":
+		cl.Deprecations = append(cl.Deprecations, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+	case "## Changelog Inclusions.### Removed":
+		cl.Removals = append(cl.Removals, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+	case "## Changelog Inclusions.### Breaking Changes":
+		cl.Breaking = append(cl.Breaking, ChangelogEntry{
+			Description: sectionText,
+			Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
+		})
+
+	}
+
+}
+
 func ParseMarkdown(body string, pr string, cl *Changelog) error {
 
 	var splits []string
@@ -29,40 +67,7 @@ func ParseMarkdown(body string, pr string, cl *Changelog) error {
 		if strings.HasPrefix(strings.TrimSpace(v), "#") {
 			// We are at a markdown section marker, if we have section text, we need to capture it
 			if len(sectionName) > 0 && len(sectionText) > 0 {
-				switch sectionName {
-				case "## Changelog Inclusions.### Additions":
-					cl.Additions = append(cl.Additions, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-				case "## Changelog Inclusions.### Changes":
-					cl.Changes = append(cl.Changes, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-				case "## Changelog Inclusions.### Fixes":
-					cl.Bugfixes = append(cl.Bugfixes, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-				case "## Changelog Inclusions.### Deprecated":
-					cl.Deprecations = append(cl.Deprecations, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-				case "## Changelog Inclusions.### Removed":
-					cl.Removals = append(cl.Removals, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-				case "## Changelog Inclusions.### Breaking Changes":
-					cl.Breaking = append(cl.Breaking, ChangelogEntry{
-						Description: sectionText,
-						Link:        fmt.Sprintf("[Pull Request #%s](https://github.com/splicemachine/splicectl/pull/%s)", pr, pr),
-					})
-
-				}
-
+				collectSectionText(cl, sectionName, sectionText, pr)
 				sections[sectionName] = sectionText
 				sectionText = ""
 			}
@@ -88,6 +93,13 @@ func ParseMarkdown(body string, pr string, cl *Changelog) error {
 				}
 			}
 		}
+	}
+	// If we exit with no enclosing section, where one of our changes sections is last in the description
+	// we need to process that last block of text we collected.
+	if len(sectionName) > 0 && len(sectionText) > 0 {
+		collectSectionText(cl, sectionName, sectionText, pr)
+		sections[sectionName] = sectionText
+		sectionText = ""
 	}
 
 	return nil

--- a/provider/mock.go
+++ b/provider/mock.go
@@ -117,6 +117,30 @@ This is the description
 
 ## Checklist
 `)
+	case "v0.0.3":
+		PRData = append(PRData, `## Description
+
+This is the description
+
+## Changelog Inclusions
+
+### Changes
+
+- Change 1
+- Change 2
+`)
+
+		PRData = append(PRData, `## Description
+
+This is the description
+
+## Changelog Inclusions
+
+### Changes
+
+- Change 3
+- Change 4
+`)
 	}
 
 	for k, v := range PRData {


### PR DESCRIPTION
## Description

Fix a problem where there isn't a markdown section below the `Changelog Inclusions` section, as it is in this template.

## Motivation and Context

We were losing the last entry when it wasn't followed by a markdown section.

## How Has This Been Tested?

A test was created for this scenario and code updated to ensure it would pass.

```bash
cd cmd
ginkgo
```

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [x] Added Changelog entries below

## Changelog Inclusions

<!-- Text Entered in these section will appear as it is written, MD formatted -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
       %> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

- Properly capture the last section of text when it isn't followed by another markdown section.

### Deprecated

### Removed

### Breaking Changes
