### PR TITLE
Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Set RELEASE_TAG env
+        run: echo RELEASE_TAG=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> ${GITHUB_ENV}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist --release-notes=changelog/${{ env.RELEASE_TAG }}.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAAHSOME_PAT: ${{ secrets.SPLICECI_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,108 @@
+env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  - REPO=github.com/maahsome/changelog-pr
+
+before:
+  hooks:
+    - go mod download
+builds:
+  - id: general
+    ldflags: &build-ldflags
+      - -X github.com/maahsome/changelog-pr/cmd.semVer=v{{ .Version }}
+      - -X github.com/maahsome/changelog-pr/cmd.buildDate={{ .CommitDate }}
+      - -X github.com/maahsome/changelog-pr/cmd.gitCommit={{ .Commit }}
+      - -X github.com/maahsome/changelog-pr/cmd.gitRef=refs/tags/{{ .Tag }}
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - id: general
+    builds:
+      - general
+    wrap_in_directory: true
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  skip: true
+
+brews:
+  - name: changelog-pr
+    ids:
+      - general
+
+    goarm: 6
+
+    # NOTE: make sure the url_template, the token and given repo (github or gitlab) owner and name are from the
+    # same kind. We will probably unify this in the next major version like it is done with scoop.
+
+    # GitHub/GitLab repository to push the formula to
+    # Gitea is not supported yet, but the support coming
+    tap:
+      owner: maahsome
+      name: homebrew-tap
+      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
+      token: "{{ .Env.MAAHSOME_PAT }}"
+
+    # Template for the url which is determined by the given Token (github or gitlab)
+    # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    # Default for gitlab is "https://gitlab.com/<repo_owner>/<repo_name>/uploads/{{ .ArtifactUploadHash }}/{{ .ArtifactName }}"
+    # Default for gitea is "https://gitea.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/maahsome/changelog-pr/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    # Allows you to set a custom download strategy. Note that you'll need
+    # to implement the strategy and add it to your tap repository.
+    # Example: https://docs.brew.sh/Formula-Cookbook#specifying-the-download-strategy-explicitly
+    # Default is empty.
+    # download_strategy: CurlDownloadStrategy.
+
+    # Allows you to add a custom require_relative at the top of the formula template
+    # Default is empty
+    # custom_require: custom_download_strategy
+
+    # Git author used to commit to the repository.
+    # Defaults are shown.
+    commit_author:
+      name: Christopher Maahs
+      email: cmaahs@gmail.com
+
+    # Folder inside the repository to put the formula.
+    # Default is the root folder.
+    folder: Formula
+
+    # Caveats for the user of your binary.
+    # Default is empty.
+    # caveats: ""
+
+    # Your app's homepage.
+    # Default is empty.
+    homepage: "https://github.com/maahsome/changelog-pr/"
+
+    # Your app's description.
+    # Default is empty.
+    description: "CLI tool for building changelog from PR descriptions based on a template"
+
+    # SPDX identifier of your app's license.
+    # Default is empty.
+    # license: "MIT"
+
+    # Setting this will prevent goreleaser to actually try to commit the updated
+    # formula - instead, the formula file will be stored on the dist folder only,
+    # leaving the responsibility of publishing it to the user.
+    # If set to auto, the release will not be uploaded to the homebrew tap
+    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
+    # Default is false.
+    # skip_upload: true
+
+    # So you can `brew test` your formula.
+    # Default is empty.
+    test: |
+      system "#{bin}/changelog-pr --help"
+
+    # Custom install script for brew.
+    # Default is 'bin.install "program"'.
+    install: |
+      bin.install "changelog-pr"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+declare SEMVER="$1"
+
+# Set sed command to gsed if running on mac
+if [[ `uname` = "Darwin" ]]; then
+    GSED=$(which gsed)
+    if [[ "${GSED}" == "gsed not found" ]]; then
+        echo "This script requires GNU-sed, please install with 'brew install gnu-sed'"
+        exit 1
+    fi
+    sed_command="gsed"
+    GDATE=$(which gdate)
+    if [[ "${GDATE}" == "gdate not found" ]]; then
+        echo "This script requires GNU-sed, please install with 'brew install gnu-sed'"
+        exit 1
+    fi
+    date_command="gdate"
+
+else
+    sed_command="sed"
+    date_command="date"
+fi
+
+BUILD_DATE=$($date_command --utc +%FT%T.%3NZ)
+GIT_TAG=$(git rev-parse HEAD)
+GIT_REF="refs/tags/${SEMVER}"
+echo "Build Date: ${BUILD_DATE}"
+echo "SemVer: ${SEMVER}"
+echo "GIT TAG: ${GIT_TAG}"
+echo "GIT REF: ${GIT_REF}"
+
+go build -ldflags "-X github.com/maahsome/changelog-pr/cmd.semVer=${SEMVER} -X 'github.com/maahsome/changelog-pr/cmd.buildDate=${BUILD_DATE}' -X github.com/maahsome/changelog-pr/cmd.gitCommit=${GIT_TAG} -X github.com/maahsome/changelog-pr/cmd.gitRef=${GIT_REF}"

--- a/changelog/v0.0.1.md
+++ b/changelog/v0.0.1.md
@@ -1,0 +1,7 @@
+## v0.0.1
+
+### Additions
+
+#### [Pull Request #1](https://github.com/maahsome/changelog-pr/pull/1)
+
+- Create a Changelog since a TAG in a GitHub repository

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	log "github.com/maahsome/changelog-pr/common"
+	"github.com/maahsome/changelog-pr/common"
 	"github.com/maahsome/changelog-pr/provider"
 	"github.com/spf13/cobra"
 )
@@ -24,24 +24,26 @@ var generateCmd = &cobra.Command{
 		releaseTag, _ := cmd.Flags().GetString("release-tag")
 		changelogFile, _ := cmd.Flags().GetString("file")
 
-		if !strings.HasPrefix(sinceTag, "v") {
-			log.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
+		if len(sinceTag) > 0 && !strings.HasPrefix(sinceTag, "v") {
+			common.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
 		}
 		if !strings.HasPrefix(releaseTag, "v") {
-			log.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
+			common.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
 		}
-		_, sterr := semver.Parse(strings.Replace(sinceTag, "v", "", 1))
-		if sterr != nil {
-			log.Logger.Fatal(fmt.Sprintf("Error parsing SemVer for %s", sinceTag))
+		if len(sinceTag) > 0 {
+			_, sterr := semver.Parse(strings.Replace(sinceTag, "v", "", 1))
+			if sterr != nil {
+				common.Logger.Fatal(fmt.Sprintf("Error parsing SemVer for %s", sinceTag))
+			}
 		}
 		_, rterr := semver.Parse(strings.Replace(releaseTag, "v", "", 1))
 		if rterr != nil {
-			log.Logger.Fatal(fmt.Sprintf("Error parsing SemVer for %s", releaseTag))
+			common.Logger.Fatal(fmt.Sprintf("Error parsing SemVer for %s", releaseTag))
 		}
 
 		glog, err := generateLog(srcPath, sinceTag, releaseTag, changelogFile)
 		if err != nil {
-			log.Logger.WithError(err).Error("Error generating the changelog")
+			common.Logger.WithError(err).Error("Error generating the changelog")
 		}
 
 		fmt.Println(glog)
@@ -85,6 +87,6 @@ func init() {
 	generateCmd.Flags().StringP("release-tag", "r", "", "Specify the new release TAG")
 	generateCmd.Flags().StringP("file", "f", "", "Specify an output file to save the changelog to")
 	generateCmd.MarkFlagRequired("path")
-	generateCmd.MarkFlagRequired("since-tag")
+	// generateCmd.MarkFlagRequired("since-tag")
 	generateCmd.MarkFlagRequired("release-tag")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,10 @@ var (
 	cfgFile     string
 	gitProvider string
 	ghToken     string
+	semVer      string
+	gitCommit   string
+	buildDate   string
+	gitRef      string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Express the 'version' of splicectl.",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		fmt.Printf("\nSemVer: %s, BuildDate: %s\nCommitID: %s, GitRef: %s\n", semVer, buildDate, gitCommit, gitRef)
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/common/parse.go
+++ b/common/parse.go
@@ -62,6 +62,7 @@ func ParseMarkdown(body string, pr string, cl *Changelog) error {
 	} else {
 		splits = strings.Split(body, "\n")
 	}
+	Logger.Debug(fmt.Sprintf("Body: %s", body))
 	for _, v := range splits {
 		Logger.Debug(fmt.Sprintf("%s\n", v))
 		if strings.HasPrefix(strings.TrimSpace(v), "#") {

--- a/provider/github.go
+++ b/provider/github.go
@@ -40,14 +40,54 @@ func parsePRNumber(msg string) (uint, error) {
 	return uint(u64), nil
 }
 
+func getUserRepository(url string) (string, string, error) {
+	// git@github.com:Maahsome/changelog-pr.git
+	// https://github.com/Maahsome/changelog-pr.git
+
+	var matches [][]string
+
+	if strings.Contains(url, "git@") {
+		var gitRegex = regexp.MustCompile(`:(.+)\/(.+).git`)
+		matches = gitRegex.FindAllStringSubmatch(url, -1)
+		if len(matches) == 0 || len(matches[0]) == 0 || len(matches[0][1]) == 0 || len(matches[0][2]) == 0 {
+			return "", "", errors.New("failed to extract git user/repository")
+		}
+	}
+	if strings.Contains(url, "https://") {
+		var httpsRegex = regexp.MustCompile(`\.com\/(.+)\/(.+).git`)
+		matches = httpsRegex.FindAllStringSubmatch(url, -1)
+		if len(matches) == 0 || len(matches[0]) == 0 || len(matches[0][1]) == 0 || len(matches[0][2]) == 0 {
+			return "", "", errors.New("failed to extract git user/repository")
+		}
+	}
+
+	return matches[0][1], matches[0][2], nil
+}
+
 // GetChangeLogSincePR - Get the changelog details from the PR description
 func (p *Github) GetChangeLogFromPR(src string, sincePR string, release string, auth AuthToken, fileName string) (string, error) {
+
+	var (
+		resp    *resty.Response
+		resperr error
+	)
 	path := src
 
 	r, err := git.PlainOpen(path)
 	if err != nil {
 		return "", errors.New("failed generation of changelog")
 	}
+
+	c, cerr := r.Config()
+	if cerr != nil {
+		return "", errors.New("failed generation of changelog")
+	}
+	common.Logger.Debug(fmt.Sprintf("Remote URL: %s", c.Remotes["origin"].URLs[0]))
+	user, repo, rerr := getUserRepository(c.Remotes["origin"].URLs[0])
+	if rerr != nil {
+		return "", errors.New("failed generation of changelog")
+	}
+	common.Logger.Info(fmt.Sprintf("User: %s, Repo: %s\n", user, repo))
 
 	tagrefs, err := r.Tags()
 	if err != nil {
@@ -102,19 +142,24 @@ func (p *Github) GetChangeLogFromPR(src string, sincePR string, release string, 
 	}
 
 	// curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/splicemachine/splicectl/pulls/5 | jq -r '.body'
-	// Figure out how to AUTHENTICATE for PRIVATE REPOS
 	restClient := resty.New()
 
 	changeLog := common.Changelog{}
 	changeLog.Version = release
 
 	for _, p := range PRs {
-		uri := fmt.Sprintf("https://api.github.com/repos/splicemachine/splicectl/pulls/%s", p)
-		resp, resperr := restClient.R().
-			SetHeader("Accept", "application/vnd.github.v3+json").
-			SetHeader("Authorization", fmt.Sprintf("token %s", auth.GithubToken)).
-			Get(uri)
-
+		uri := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%s", user, repo, p)
+		common.Logger.Debug(fmt.Sprintf("PR URI: %s", uri))
+		if len(auth.GithubToken) > 0 {
+			resp, resperr = restClient.R().
+				SetHeader("Accept", "application/vnd.github.v3+json").
+				SetHeader("Authorization", fmt.Sprintf("token %s", auth.GithubToken)).
+				Get(uri)
+		} else {
+			resp, resperr = restClient.R().
+				SetHeader("Accept", "application/vnd.github.v3+json").
+				Get(uri)
+		}
 		if resperr != nil {
 			common.Logger.WithError(resperr).Error("Error getting PR")
 		}

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,22 @@
+# RELEASE Process
+
+- export RELEASE_VERSION={newSemVer}
+  - where {newSemVer} is in the form of `v0.1.0`
+  - `export RELEASE_VERSION=v0.0.0`
+- Create a new branch for release.
+  - `git checkout -b RELEASE_${RELEASE_VERSION}`
+- Create the changelog file `changelog/${RELEASE_VERSION}.md`
+  - `go build` (# from the source root)
+  - `./changelog-pr generate -p . -r "${RELEASE_VERSION}"`
+    - Inspect the output from the above command, then run with the `--file` parameter
+  - `./changelog-pr generate -p . -r "${RELEASE_VERSION}"` -f ./changelog/${RELEASE_VERSION}.md
+- Review changelogs/releases/${RELEASE_VERSION}.md
+- Create and Merge PR
+  - `git add -A; git commit -m "RELEASE of ${RELEASE_VERSION}"; git push origin RELEASE_${RELEASE_VERSION}`
+- Pull main
+  - `git checkout main; git fetch; git pull`
+- Perform the release
+  - `git tag ${RELEASE_VERSION}`
+  - `git push origin ${RELEASE_VERSION}`
+- Check to see if Release GitHub Action kicks off
+- Check maahsome/changelog-pr Releases Page, and maahsome/homebrew-tap/Formula/changelog-pr.rb


### PR DESCRIPTION
## Description

Added a 'version' command.
Setup release via github actions and goreleaser
Manually added v0.0.1.md changelog file.
Added a release/README.md document to follow for releasing

## Motivation and Context

Getting to a workable solution.

## How Has This Been Tested?

```bash
cd cmd
ginkgo
```

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [x] Added Changelog entries below

## Changelog Inclusions

### Additions

- 'version' command, containing the standard version info

### Changes

- 'generate' no longer requires a `--since-tag`, it will grab the last semver based tag.

### Fixes

- removed some hardcoded references used during initial developement
  - Extracting the user/repo from the github url.

### Deprecated

### Removed

### Breaking Changes

