### PR TITLE
fix: forgot to change a reference for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
           args: release --rm-dist --release-notes=changelog/${{ env.RELEASE_TAG }}.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MAAHSOME_PAT: ${{ secrets.SPLICECI_PAT }}
+          MAAHSOME_PAT: ${{ secrets.MAAHSOME_PAT }}


### PR DESCRIPTION
## Description

Fix a reference for the secret to update the homebrew-tap.

## Motivation and Context

Release errors.

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [ ] Added Changelog entries below

## Changelog Inclusions

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

