### PR TITLE
chore: fix the PR template, no leading pound sign on any line

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,10 +25,12 @@ If the pull request includes user-facing changes, please fill out the [Changelog
 ## Changelog Inclusions
 
 <!-- Text Entered in these section will appear as it is written, MD formatted -->
+<!-- Avoid using the # character as the first character on any line, a trim is -->
+<!-- performed on each line when checking for markdown section tags -->
 - base feature note
   - **BREAKING** note on base feature
   - Basically whatever formatting we have here, just plain-text
-       #> command example
+       %> command example
 - next feature
   - note on next feature
 <!-- If there is NO text in a section, no entries will be collected for that section -->


### PR DESCRIPTION
## Description

Remove leading # in the example text for the PR template

## Motivation and Context

Having leading # on any line in the markdown text causes processing to have issues.

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [ ] Added Changelog entries below

## Changelog Inclusions

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

