### PR TITLE
feat: more examples, template output

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -16,7 +16,30 @@ var generateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "Generate a Changelog from PR descriptions since a specified TAG",
 	Long: `EXAMPLE:
-	#> changelog-pr generate --path <path/to/git/src> --since-tag v0.1.0 --release-tag v0.2.0
+	In this example we will look at all PRs that have been merged since the repository
+	was tagged with 'v0.1.0'
+
+	  %> changelog-pr generate --path <path/to/git/src> --since-tag v0.1.0 --release-tag v0.2.0
+
+EXAMPLE:
+	In this example the very last semver based TAG will be used as the '--since-tag'
+
+	  %> changelog-pr generate --path . --release-tag v0.2.1
+
+EXAMPLE:
+	In this example we will create a <SEMVER>.md changelog file.  If the release file already exists,
+	data will be appended to the already existing file, allowing one to update a master changelog.md
+	file
+
+	  %> RELEASE_VERSION="v0.2.1"
+	  %> changelog-pr generate --path . --release-tag ${RELEASE_VERSION} --file changelog/${RELEASE_VERSION.md}
+
+EXAMPLE:
+	In this example, the repository is private and requires a Personal Access Token to access the PR information.
+
+	  %> # fetch your personal access token from whereever you store your secrets
+	  %> GIT_PAT=$(security find-generic-password -l "git_pat" -w scripting.keychain-db)
+	  %> changelog-pr generate --path . --release-tag "v0.2.3" --gh-token ${GIT_PAT}
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		srcPath, _ := cmd.Flags().GetString("path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,12 @@ var rootCmd = &cobra.Command{
 	Use:   "changelog-pr",
 	Short: "Generate a changelog from PR descriptions",
 	Long: `Given a previous git TAG, locate all of the PRs since that TAG, and parse the
-	description of the PR for specific MD sections and build a changelog from the data.`,
+	description of the PR for specific MD sections and build a changelog from the data.
+
+	Currently there is only support for GitHub repositories, though adding different git
+	providers should be fairly straight forward.
+
+	Use the 'changelog-pr template' command to display the PR TEMPLATE data`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logFile, _ := cmd.Flags().GetString("log-file")
 		logLevel, _ := cmd.Flags().GetString("log-level")

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// templateCmd represents the template command
+var templateCmd = &cobra.Command{
+	Use:   "template",
+	Short: "Output the markdown that needs to be added to the PR template",
+	Long:  `This command outputs the markdown that is added to the '.github/PULL_REQUEST_TEMPLATE.md' file`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(`## Changelog Inclusions
+
+<!-- Text Entered in these sections will appear as it is written, MD formatted -->
+<!-- Avoid using the # character as the first character on any line, a trim is -->
+<!-- performed on each line when checking for markdown section tags -->
+- base feature note
+  - **BREAKING** note on base feature
+  - Basically whatever formatting we have here, just plain-text
+	%> command example
+- next feature
+  - note on next feature
+<!-- If there is NO text in a section, no entries will be collected for that section -->
+
+### Additions
+
+### Changes
+
+### Fixes
+
+### Deprecated
+
+### Removed
+
+### Breaking Changes`)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(templateCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Express the 'version' of splicectl.",
+	Short: "Express the 'version' of changelog-pr.",
 	Run: func(cmd *cobra.Command, args []string) {
 
 		fmt.Printf("\nSemVer: %s, BuildDate: %s\nCommitID: %s, GitRef: %s\n", semVer, buildDate, gitCommit, gitRef)


### PR DESCRIPTION
## Description

Added examples to all the commands.
Added a 'template' command to output the markdown to add to the PULL REQUEST TEMPLATE

## Motivation and Context

Who doesn't like good CLI examples?

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [x] Added Changelog entries below

## Changelog Inclusions

### Additions

- new examples for commands

### Fixes

- version incorrect reference

