### PR TITLE
feat: less restrictive tag selections, check branch commits

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -47,12 +47,6 @@ EXAMPLE:
 		releaseTag, _ := cmd.Flags().GetString("release-tag")
 		changelogFile, _ := cmd.Flags().GetString("file")
 
-		if len(sinceTag) > 0 && !strings.HasPrefix(sinceTag, "v") {
-			common.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
-		}
-		if !strings.HasPrefix(releaseTag, "v") {
-			common.Logger.Fatal("Please provide TAGs in format 'vMAJOR.MINOR.PATCH'")
-		}
 		if len(sinceTag) > 0 {
 			_, sterr := semver.Parse(strings.Replace(sinceTag, "v", "", 1))
 			if sterr != nil {

--- a/common/parse.go
+++ b/common/parse.go
@@ -62,9 +62,10 @@ func ParseMarkdown(body string, pr string, cl *Changelog) error {
 	} else {
 		splits = strings.Split(body, "\n")
 	}
-	Logger.Debug(fmt.Sprintf("Body: %s", body))
+	Logger.Info(fmt.Sprintf("Searching PR#%s for Changelog Inclusions...", pr))
+	Logger.Trace(fmt.Sprintf("Body: %s", body))
 	for _, v := range splits {
-		Logger.Debug(fmt.Sprintf("%s\n", v))
+		Logger.Trace(fmt.Sprintf("%s\n", v))
 		if strings.HasPrefix(strings.TrimSpace(v), "#") {
 			// We are at a markdown section marker, if we have section text, we need to capture it
 			if len(sectionName) > 0 && len(sectionText) > 0 {
@@ -77,13 +78,13 @@ func ParseMarkdown(body string, pr string, cl *Changelog) error {
 				currentDepth = 2
 				depthNames[currentDepth] = strings.TrimSpace(v)
 				sectionName = strings.TrimSpace(v)
-				Logger.Info(sectionName)
+				Logger.Debug(sectionName)
 			}
 			if strings.HasPrefix(strings.TrimSpace(v), "### ") {
 				currentDepth = 3
 				depthNames[currentDepth] = strings.TrimSpace(v)
 				sectionName = fmt.Sprintf("%s.%s", depthNames[2], strings.TrimSpace(v))
-				Logger.Info(sectionName)
+				Logger.Debug(sectionName)
 			}
 		} else {
 			// We are not at a markdown section, collect the section text


### PR DESCRIPTION
## Description

Clearly checking for valid semver on TAGs was a bad idea.
  - removed that check
If you select a '--since-tag' that is a commit that isn't available from the selected branch, we need to fail or it will process ALL of the PRs

## Motivation and Context

Make the tool more widely usable.

## How Has This Been Tested?

Testing against changelog-pr, splicectl, and pysplice repositories.

## Checklist

If the pull request includes user-facing changes, please fill out the [Changelog Inclusions](#changelog-inclusions) section.

- [x] Added Changelog entries below

## Changelog Inclusions

### Additions

### Changes

- A bunch of logging movement (Debug->Trace, Info->Debug, etc)
- Checking the TAG commit ID to ensure it is reachable in the current branch

### Fixes

- Specifying tags no longer requires SEMVER valid tags
  - With the exception if you don't specify '--since-tag', everything is converted to SEMVER and compared.

### Deprecated

### Removed

### Breaking Changes

